### PR TITLE
Implement mana system with regeneration

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,11 @@
 
 
   <!-- ❤️ Health Bar -->
-  <div class="hearts" data-hearts></div>
+  <div class="hearts hide" data-hearts></div>
+  <!-- 💜 Mana Bar -->
+  <div class="mana-bar hide">
+    <div class="mana-fill" data-mana-fill></div>
+  </div>
 
 
   <!-- 🌍 World Container -->

--- a/mana.js
+++ b/mana.js
@@ -1,0 +1,35 @@
+// mana.js
+const MAX_MANA = 100
+const MANA_REGEN_RATE = 0.01 // mana per ms (~10 per second)
+const ATTACK_MANA_COST = 20
+
+let currentMana = MAX_MANA
+
+const manaFillElem = document.querySelector('[data-mana-fill]')
+
+export function setupMana() {
+  currentMana = MAX_MANA
+  updateManaDisplay()
+}
+
+export function updateMana(delta) {
+  currentMana = Math.min(MAX_MANA, currentMana + MANA_REGEN_RATE * delta)
+  updateManaDisplay()
+}
+
+export function spendMana(cost = ATTACK_MANA_COST) {
+  if (currentMana >= cost) {
+    currentMana -= cost
+    updateManaDisplay()
+    return true
+  }
+  return false
+}
+
+function updateManaDisplay() {
+  if (manaFillElem) {
+    manaFillElem.style.width = `${(currentMana / MAX_MANA) * 100}%`
+  }
+}
+
+export { currentMana, MAX_MANA, ATTACK_MANA_COST }

--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ import { setupProjectiles, updateProjectiles } from './projectile.js'
 import { setupWerewolves, updateWerewolves, getWerewolfElements } from './werewolf.js'
 import { getCustomProperty } from './updateCustomProperty.js'
 import { setupDivineKnight, walkOntoScreen } from './divineKnight.js'
+import { setupMana, updateMana } from './mana.js'
 
 const WORLD_WIDTH = 100
 const WORLD_HEIGHT = 30
@@ -32,6 +33,7 @@ const dialogueMood = document.getElementById('dialogue-mood')
 const gameOverMusic = document.querySelector('[data-gameovermusic]')
 const combatMusic = document.querySelector('[data-combatmusic]')
 const heartContainer = document.querySelector('[data-hearts]')
+const manaBar = document.querySelector('.mana-bar')
 const screenFlash = document.getElementById('screen-flash')
 const transitionOverlay = document.getElementById('transition-overlay')
 const dialogueBg = document.getElementById('dialogue-bg')
@@ -42,6 +44,10 @@ const avatarElem = document.getElementById('avatar')
 const speakerNameElem = document.getElementById('speaker-name')
 const bossBg = document.getElementById('boss-bg')
 const controlsScreenElem = document.querySelector('[data-controls-screen]')
+
+// hide UI elements until gameplay begins
+heartContainer.classList.add('hide')
+manaBar.classList.add('hide')
 
 let lastTime
 let speedScale
@@ -103,6 +109,7 @@ function update(time) {
   updateProjectiles(delta, cameraX, WORLD_WIDTH, getCrossRects())
   updateSpeedScale(delta)
   updateDistance()
+  updateMana(delta)
 
   if (!isInvincible && (checkCrossCollision() || checkWerewolfCollision())) {
     removeHeart()
@@ -289,6 +296,7 @@ function handleStart() {
   const fg = document.querySelector('.farground')
   if (fg) fg.style.display = ''
   currentHearts = MAX_HEARTS
+  setupMana()
   isStaggered = false
   isInvincible = false
   isGameOver = false
@@ -308,6 +316,7 @@ function handleStart() {
   endScreenElem.classList.add('hide')
   gameAreaElem.classList.remove('hide')
   heartContainer.classList.remove('hide')
+  manaBar.classList.remove('hide')
   dialogueBox.classList.add('hidden')
   controlsScreenElem.classList.add('hide')
 
@@ -329,6 +338,7 @@ function handleLose() {
   deathSound.volume = 0.5
 
   heartContainer.classList.add('hide')
+  manaBar.classList.add('hide')
 
   myMusic.pause()
   myMusic.currentTime = 0

--- a/style.css
+++ b/style.css
@@ -169,6 +169,27 @@ body {
   z-index: 999;
 }
 
+.mana-bar {
+  position: fixed;
+  top: 10vmin;
+  left: 2vmin;
+  width: 30vmin;
+  height: 2.5vmin;
+  border: 2px solid #4b006e;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 1.5vmin;
+  box-shadow: 0 0 0.5vmin #000 inset, 0 0 1vmin #4b006e;
+  overflow: hidden;
+  z-index: 999;
+}
+
+.mana-fill {
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(90deg, #bd5cff, #6a0dad);
+  transition: width 0.2s;
+}
+
 .heart {
   width: 6vmin;
   height: auto;

--- a/vampire.js
+++ b/vampire.js
@@ -5,7 +5,8 @@ import {
     incrementCustomProperty,
     setCustomProperty
   } from './updateCustomProperty.js'
-  import { createProjectile } from './projectile.js'
+import { createProjectile } from './projectile.js'
+import { spendMana } from './mana.js'
   
   const vampireElem = document.querySelector('[data-vampire]')
   const JUMP_SPEED = 0.45
@@ -206,6 +207,7 @@ import {
   
   function onAttack() {
     if (isAttacking || isJumping) return
+    if (!spendMana()) return
     isAttacking = true
     attackFrame = 0
     currentAttackFrameTime = 0


### PR DESCRIPTION
## Summary
- add purple mana bar to UI
- implement mana tracking with regeneration and attack cost
- block attacks when mana is insufficient
- hide/show mana bar with start and lose transitions
- refine mana bar style and hide UI until gameplay begins

## Testing
- `node --check script.js`
- `node --check mana.js`


------
https://chatgpt.com/codex/tasks/task_e_684c3763e01c8322bac1aec22bb605b0