### PR TITLE
Improve mana bar and music timing

### DIFF
--- a/mana.js
+++ b/mana.js
@@ -2,24 +2,32 @@
 const MAX_MANA = 100
 const MANA_REGEN_RATE = 0.01 // mana per ms (~10 per second)
 const ATTACK_MANA_COST = 20
+const MANA_REGEN_DELAY = 1000 // ms delay before regen starts after spending
 
 let currentMana = MAX_MANA
+let regenCooldown = 0
 
 const manaFillElem = document.querySelector('[data-mana-fill]')
 
 export function setupMana() {
   currentMana = MAX_MANA
+  regenCooldown = 0
   updateManaDisplay()
 }
 
 export function updateMana(delta) {
-  currentMana = Math.min(MAX_MANA, currentMana + MANA_REGEN_RATE * delta)
+  if (regenCooldown > 0) {
+    regenCooldown -= delta
+  } else {
+    currentMana = Math.min(MAX_MANA, currentMana + MANA_REGEN_RATE * delta)
+  }
   updateManaDisplay()
 }
 
 export function spendMana(cost = ATTACK_MANA_COST) {
   if (currentMana >= cost) {
     currentMana -= cost
+    regenCooldown = MANA_REGEN_DELAY
     updateManaDisplay()
     return true
   }

--- a/script.js
+++ b/script.js
@@ -199,6 +199,8 @@ function startBossFight() {
   console.log('Boss fight begins!')
   myMusic.pause()
   myMusic.currentTime = 0
+  dialogueMood.pause()
+  dialogueMood.currentTime = 0
   combatMusic.currentTime = 0
   combatMusic.volume = 0.4
   combatMusic.play()

--- a/style.css
+++ b/style.css
@@ -171,10 +171,10 @@ body {
 
 .mana-bar {
   position: fixed;
-  top: 10vmin;
+  top: 8vmin;
   left: 2vmin;
-  width: 30vmin;
-  height: 3vmin;
+  width: 25vmin;
+  height: 2vmin;
   border: 2px solid #5a1e70;
   background: rgba(30, 0, 40, 0.5);
   border-radius: 8px;


### PR DESCRIPTION
## Summary
- adjust mana bar placement and size to sit closer to the hearts
- add a short delay before mana begins to regenerate
- stop dialogue music when the boss fight begins

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c4127175883229ed8d609954be40b