### PR TITLE
Fix boss arena background and improve mana display

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,11 @@
   <!-- ❤️ Health Bar -->
   <div class="hearts" data-hearts></div>
   <!-- 💜 Mana Bar -->
-  <div class="mana-bar hide">
-    <div class="mana-fill" data-mana-fill></div>
+  <div class="mana-container hide">
+    <div class="mana-label">Vampiric Essence</div>
+    <div class="mana-bar">
+      <div class="mana-fill" data-mana-fill></div>
+    </div>
   </div>
 
 

--- a/mana.js
+++ b/mana.js
@@ -2,7 +2,7 @@
 const MAX_MANA = 100
 const MANA_REGEN_RATE = 0.01 // mana per ms (~10 per second)
 const ATTACK_MANA_COST = 20
-const MANA_REGEN_DELAY = 1000 // ms delay before regen starts after spending
+const MANA_REGEN_DELAY = 1500 // ms delay before regen starts after spending
 
 let currentMana = MAX_MANA
 let regenCooldown = 0

--- a/script.js
+++ b/script.js
@@ -33,7 +33,7 @@ const dialogueMood = document.getElementById('dialogue-mood')
 const gameOverMusic = document.querySelector('[data-gameovermusic]')
 const combatMusic = document.querySelector('[data-combatmusic]')
 const heartContainer = document.querySelector('[data-hearts]')
-const manaBar = document.querySelector('.mana-bar')
+const manaContainer = document.querySelector('.mana-container')
 const screenFlash = document.getElementById('screen-flash')
 const transitionOverlay = document.getElementById('transition-overlay')
 const dialogueBg = document.getElementById('dialogue-bg')
@@ -239,9 +239,10 @@ function transitionToBossArea() {
   setTimeout(() => {
     document.querySelectorAll('[data-background]').forEach(bg => bg.style.display = 'none')
     document.querySelectorAll('[data-midground]').forEach(mg => mg.style.display = 'none')
-    document.querySelectorAll('[data-ground]').forEach(g => g.style.display = 'none')
+    document.querySelectorAll('[data-ground]').forEach(g => g.style.display = '')
     const fg = document.querySelector('.farground')
-    if (fg) fg.style.display = 'none'
+    if (fg) fg.style.display = ''
+    setupGround()
     bossBg.classList.remove('hide')
     setupDivineKnight()
     cameraX = 0
@@ -314,7 +315,7 @@ function handleStart() {
   endScreenElem.classList.add('hide')
   gameAreaElem.classList.remove('hide')
   heartContainer.classList.remove('hide')
-  manaBar.classList.remove('hide')
+  manaContainer.classList.remove('hide')
   dialogueBox.classList.add('hidden')
   controlsScreenElem.classList.add('hide')
 
@@ -336,7 +337,7 @@ function handleLose() {
   deathSound.volume = 0.5
 
   heartContainer.classList.add('hide')
-  manaBar.classList.add('hide')
+  manaContainer.classList.add('hide')
 
   myMusic.pause()
   myMusic.currentTime = 0

--- a/style.css
+++ b/style.css
@@ -169,10 +169,24 @@ body {
   z-index: 999;
 }
 
-.mana-bar {
+.mana-container {
   position: fixed;
-  top: 8vmin;
-  left: 2vmin;
+  top: 2vmin;
+  right: 2vmin;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  z-index: 999;
+}
+
+.mana-label {
+  font-family: VT323-Regular;
+  font-size: 4vmin;
+  color: #d6c2e7;
+  margin-bottom: 1vmin;
+}
+
+.mana-bar {
   width: 25vmin;
   height: 2vmin;
   border: 2px solid #5a1e70;
@@ -180,7 +194,6 @@ body {
   border-radius: 8px;
   overflow: hidden;
   box-shadow: 0 0 6px rgba(90, 30, 112, 0.6);
-  z-index: 999;
 }
 
 .mana-fill {


### PR DESCRIPTION
## Summary
- add mana container with `Vampiric Essence` label and move to top-right
- tweak styles for new mana UI
- show ground and foreground in boss arena and reset ground
- slightly delay mana regeneration

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c442e4e588322b635b99a40a8fd6d