### PR TITLE
Fix parallax layers and boss idle state

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,6 @@
 <body>
 
   <!-- 🌌 Static Background Layers -->
-  <img src="assets/images/backgrounds/foreground.png" class="background" data-background hidden />
-  <img src="assets/images/backgrounds/foreground.png" class="background" data-background hidden />
   <img id="boss-bg" src="assets/images/backgrounds/boss-1-background.PNG" class="boss-bg hide" />
   <img src="assets/images/backgrounds/farground.png" class="farground" alt="Far Ground" />
   <img src="assets/images/backgrounds/foreground.png" class="foreground" alt="Foreground" />

--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,8 @@ import {
   getVampireX,
   setMoveDirection,
   enableInput,
-  setVampireLeft
+  setVampireLeft,
+  enterIdle
 } from './vampire.js'
 import { setupCross, updateCross, getCrossRects } from './cross.js'
 import { setupProjectiles, updateProjectiles } from './projectile.js'
@@ -272,6 +273,7 @@ function stepIntoCenter(time) {
   lastTime = time
   if (getVampireX() >= 50) {
     setMoveDirection(0)
+    enterIdle()
     triggerBossEncounter()
   } else {
     requestAnimationFrame(stepIntoCenter)

--- a/js/vampire.js
+++ b/js/vampire.js
@@ -213,6 +213,12 @@ import { spendMana } from './mana.js'
     currentAttackFrameTime = 0
     vampireElem.src = 'assets/images/carmilla/attack/carmilla-attack000.png'
   }
+
+  export function enterIdle() {
+    idleFrame = 0
+    currentIdleFrameTime = 0
+    vampireElem.src = 'assets/images/carmilla/idle/carmilla-idle000.png'
+  }
   
 
   export function setMoveDirection(dir) {


### PR DESCRIPTION
## Summary
- remove duplicate foreground image that moved with the background
- import new helper `enterIdle` for Carmilla
- call `enterIdle` when she stops in the boss intro

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c62abda6c8322bd4b2f8a93106c1b