### PR TITLE
Improve parallax and add screen shake on damage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -340,6 +340,16 @@ body {
   animation: fadeInSlow 2s ease-out;
 }
 
+@keyframes screenShake {
+  0%, 100% { transform: translate(0, 0); }
+  20%, 60% { transform: translate(-3px, 0); }
+  40%, 80% { transform: translate(3px, 0); }
+}
+
+body.shake {
+  animation: screenShake 0.3s;
+}
+
 .hidden {
   display: none !important;
 }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,8 @@
   <!-- 🌌 Static Background Layers -->
   <img id="boss-bg" src="assets/images/backgrounds/boss-1-background.PNG" class="boss-bg hide" />
   <img src="assets/images/backgrounds/farground.png" class="farground" alt="Far Ground" />
-  <img src="assets/images/backgrounds/foreground.png" class="foreground" alt="Foreground" />
+  <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
+  <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
   <img src="assets/images/title-bg.png" id="title-bg" alt="Title Background" />
 
 

--- a/js/ground.js
+++ b/js/ground.js
@@ -6,12 +6,13 @@ import {
 const GROUND_WIDTH = 100
 const MIDGROUND_WIDTH = 100
 const BACKGROUND_WIDTH = 100
-const FOREGROUND_SPEED = 0.1
+const FOREGROUND_WIDTH = 100
+const FOREGROUND_SPEED = 1.2
 
 const groundElems = document.querySelectorAll("[data-ground]")
 const midgroundElems = document.querySelectorAll("[data-midground]")
 const backgroundElems = document.querySelectorAll("[data-background]")
-const foregroundElem = document.querySelector('.foreground')
+const foregroundElems = document.querySelectorAll('[data-foreground]')
 
 export function setupGround() {
   groundElems.forEach((ground, i) => {
@@ -19,9 +20,10 @@ export function setupGround() {
     ground.dataset.index = i
   })
 
-  if (foregroundElem) {
-    setCustomProperty(foregroundElem, "--left", 0)
-  }
+  foregroundElems.forEach((fg, i) => {
+    setCustomProperty(fg, "--left", i * FOREGROUND_WIDTH)
+    fg.dataset.index = i
+  })
 
   midgroundElems.forEach((mg, i) => {
     setCustomProperty(mg, "--left", i * MIDGROUND_WIDTH)
@@ -58,10 +60,13 @@ export function updateGround(cameraX) {
     setCustomProperty(bg, "--left", left)
   })
 
-  if (foregroundElem) {
-    const fgLeft = -cameraX * FOREGROUND_SPEED
-    setCustomProperty(foregroundElem, "--left", fgLeft)
-  }
+  const fgCamera = cameraX * FOREGROUND_SPEED
+  const fgOffset = fgCamera % FOREGROUND_WIDTH
+  const baseFg = Math.floor(fgCamera / FOREGROUND_WIDTH)
+  foregroundElems.forEach((fg, i) => {
+    const left = (baseFg + i) * FOREGROUND_WIDTH - fgOffset
+    setCustomProperty(fg, "--left", left)
+  })
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -50,7 +50,6 @@ let lastTime
 let speedScale
 let currentHearts
 let isGameOver = false
-let isStaggered = false
 let isInvincible = false
 let cameraX = 0
 let distance = 0
@@ -125,7 +124,7 @@ function update(time) {
 
 // Margin‐based dead‐zone at the edges
 function updatePlayerAndCamera(delta) {
-  if (!isStaggered) updateVampire(delta, speedScale);
+  updateVampire(delta, speedScale);
 
   const x = getVampireX();
   const halfW = WORLD_WIDTH / 2;
@@ -243,8 +242,7 @@ function transitionToBossArea() {
     document.querySelectorAll('[data-ground]').forEach(g => g.style.display = '')
     const far = document.querySelector('.farground')
     if (far) far.style.display = ''
-    const fg = document.querySelector('.foreground')
-    if (fg) fg.style.display = ''
+    document.querySelectorAll('.foreground').forEach(fg => fg.style.display = '')
     setupGround()
     bossBg.classList.remove('hide')
     setupDivineKnight()
@@ -298,11 +296,9 @@ function handleStart() {
   document.querySelectorAll('[data-ground]').forEach(g => g.style.display = '')
   const far = document.querySelector('.farground')
   if (far) far.style.display = ''
-  const fg = document.querySelector('.foreground')
-  if (fg) fg.style.display = ''
+  document.querySelectorAll('.foreground').forEach(fg => fg.style.display = '')
   currentHearts = MAX_HEARTS
   setupMana()
-  isStaggered = false
   isInvincible = false
   isGameOver = false
   updateHeartDisplay()
@@ -392,11 +388,11 @@ function handleLose() {
   vampireElem.classList.add('damaged')
   screenFlash.classList.add('active')
   setTimeout(() => screenFlash.classList.remove('active'), 100)
-  isStaggered = true
+  document.body.classList.add('shake')
   isInvincible = true
+  setTimeout(() => document.body.classList.remove('shake'), 300)
   setTimeout(() => {
     vampireElem.classList.remove('damaged')
-    isStaggered = false
   }, 300)
   setTimeout(() => (isInvincible = false), 1000)
 }


### PR DESCRIPTION
## Summary
- make foreground parallax repeat and move the fastest
- add subtle screen shake effect when damage is taken
- remove player freeze when hit

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c6555410c832281461b98b3df522c