### PR TITLE
Fix parallax and idle animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <img src="assets/images/backgrounds/farground.png" class="farground" alt="Far Ground" />
   <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
   <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
+  <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
   <img src="assets/images/title-bg.png" id="title-bg" alt="Title Background" />
 
 
@@ -42,6 +43,7 @@
       <img src="assets/images/backgrounds/midground-2.png" class="midground" data-midground />
       <img src="assets/images/backgrounds/midground-1.png" class="midground" data-midground />
       <img src="assets/images/backgrounds/midground-2.png" class="midground" data-midground />
+      <img src="assets/images/backgrounds/midground-1.png" class="midground" data-midground />
 
       <!-- Ground Tiles -->
       <img src="assets/images/backgrounds/ground.PNG" class="ground" data-ground />

--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,9 @@ import {
   setMoveDirection,
   enableInput,
   setVampireLeft,
-  enterIdle
+  enterIdle,
+  startIdleLoop,
+  stopIdleLoop
 } from './vampire.js'
 import { setupCross, updateCross, getCrossRects } from './cross.js'
 import { setupProjectiles, updateProjectiles } from './projectile.js'
@@ -204,6 +206,9 @@ function startBossFight() {
   combatMusic.currentTime = 0
   combatMusic.volume = 0.4
   combatMusic.play()
+  stopIdleLoop()
+  lastTime = null
+  window.requestAnimationFrame(update)
 }
 
 function runOffscreen() {
@@ -272,6 +277,7 @@ function stepIntoCenter(time) {
   if (getVampireX() >= 50) {
     setMoveDirection(0)
     enterIdle()
+    startIdleLoop()
     triggerBossEncounter()
   } else {
     requestAnimationFrame(stepIntoCenter)
@@ -302,6 +308,8 @@ function handleStart() {
   isInvincible = false
   isGameOver = false
   updateHeartDisplay()
+
+  stopIdleLoop()
 
   setupGround()
   setupVampire()

--- a/js/vampire.js
+++ b/js/vampire.js
@@ -36,6 +36,8 @@ import { spendMana } from './mana.js'
   let moveDirection = 0
   let facingDirection = 1
   let inputEnabled = false
+  let idleLoopId = null
+  let idleLastTime = null
   
   export function setupVampire() {
     isJumping = false
@@ -219,6 +221,31 @@ import { spendMana } from './mana.js'
     currentIdleFrameTime = 0
     vampireElem.src = 'assets/images/carmilla/idle/carmilla-idle000.png'
   }
+
+  export function startIdleLoop() {
+    if (idleLoopId != null) return
+    idleLastTime = null
+    const step = time => {
+      if (idleLastTime == null) {
+        idleLastTime = time
+        idleLoopId = requestAnimationFrame(step)
+        return
+      }
+      const delta = time - idleLastTime
+      idleLastTime = time
+      handleIdle(delta)
+      idleLoopId = requestAnimationFrame(step)
+    }
+    idleLoopId = requestAnimationFrame(step)
+  }
+
+  export function stopIdleLoop() {
+    if (idleLoopId != null) {
+      cancelAnimationFrame(idleLoopId)
+      idleLoopId = null
+      idleLastTime = null
+    }
+  }
   
 
   export function setMoveDirection(dir) {
@@ -237,5 +264,6 @@ import { spendMana } from './mana.js'
       inputEnabled = false
     }
   }
+
 
 


### PR DESCRIPTION
## Summary
- ensure midground and foreground images have enough duplicates for scrolling
- keep Carmilla's idle animation running during cutscenes
- resume gameplay loop after dialogue transitions

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c67bd5dc08322a1e3524fd138546c