### PR TITLE
Fix foreground parallax gaps

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
   <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
   <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
   <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
+  <img src="assets/images/backgrounds/foreground.png" class="foreground" data-foreground alt="Foreground" />
   <img src="assets/images/title-bg.png" id="title-bg" alt="Title Background" />
 
 

--- a/js/ground.js
+++ b/js/ground.js
@@ -62,7 +62,7 @@ export function updateGround(cameraX) {
 
   const fgCamera = cameraX * FOREGROUND_SPEED
   const fgOffset = fgCamera % FOREGROUND_WIDTH
-  const baseFg = Math.floor(fgCamera / FOREGROUND_WIDTH)
+  const baseFg = Math.floor(fgCamera / FOREGROUND_WIDTH) - 1
   foregroundElems.forEach((fg, i) => {
     const left = (baseFg + i) * FOREGROUND_WIDTH - fgOffset
     setCustomProperty(fg, "--left", left)


### PR DESCRIPTION
## Summary
- add a fourth foreground layer image
- offset foreground parallax calculation to keep a tile behind the camera

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7011f68c8322bef45220d6593e71