### PR TITLE
Fix foreground parallax speed

### DIFF
--- a/js/ground.js
+++ b/js/ground.js
@@ -62,7 +62,7 @@ export function updateGround(cameraX) {
 
   const fgCamera = cameraX * FOREGROUND_SPEED
   const fgOffset = fgCamera % FOREGROUND_WIDTH
-  const baseFg = Math.floor(fgCamera / FOREGROUND_WIDTH) - 1
+  const baseFg = Math.floor(cameraX / FOREGROUND_WIDTH) - 1
   foregroundElems.forEach((fg, i) => {
     const left = (baseFg + i) * FOREGROUND_WIDTH - fgOffset
     setCustomProperty(fg, "--left", left)


### PR DESCRIPTION
## Summary
- correct foreground offset logic so the layer always moves faster than the ground

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c7a17f17083228f010d0ce1747026