### PR TITLE
Fix foreground scroll and add boss health UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -218,6 +218,39 @@ body {
   background: linear-gradient(to right, #9742ff, #5b1ca6);
 }
 
+.boss-health {
+  position: fixed;
+  top: 2vmin;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  z-index: 999;
+  font-family: VT323-Regular;
+  color: crimson;
+}
+
+.boss-name {
+  font-size: 5vmin;
+  margin-bottom: 1vmin;
+}
+
+.boss-health-bar {
+  width: 35vmin;
+  height: 2vmin;
+  border: 2px solid crimson;
+  background: rgba(30, 0, 40, 0.5);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.boss-health-fill {
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(to right, crimson, darkred);
+}
+
 .heart {
   width: 6vmin;
   height: auto;

--- a/index.html
+++ b/index.html
@@ -29,6 +29,13 @@
       <div class="mana-fill" data-mana-fill></div>
     </div>
   </div>
+  <!-- 🛡 Boss Health -->
+  <div id="boss-health" class="boss-health hide">
+    <div class="boss-name">Divine Knight Seraphiel</div>
+    <div class="boss-health-bar">
+      <div class="boss-health-fill" id="boss-health-fill"></div>
+    </div>
+  </div>
 
 
   <!-- 🌍 World Container -->

--- a/js/boss.js
+++ b/js/boss.js
@@ -1,0 +1,29 @@
+const bossContainer = document.getElementById('boss-health');
+const bossFill = document.getElementById('boss-health-fill');
+const bossNameElem = bossContainer ? bossContainer.querySelector('.boss-name') : null;
+
+const MAX_HEALTH = 100;
+let currentHealth = MAX_HEALTH;
+
+export function showBossHealth(name = '') {
+  if (bossNameElem) bossNameElem.textContent = name;
+  currentHealth = MAX_HEALTH;
+  updateDisplay();
+  if (bossContainer) bossContainer.classList.remove('hide');
+}
+
+export function hideBossHealth() {
+  if (bossContainer) bossContainer.classList.add('hide');
+}
+
+export function damageBoss(amount) {
+  currentHealth = Math.max(0, currentHealth - amount);
+  updateDisplay();
+  return currentHealth <= 0;
+}
+
+function updateDisplay() {
+  if (bossFill) bossFill.style.width = `${(currentHealth / MAX_HEALTH) * 100}%`;
+}
+
+export { MAX_HEALTH };

--- a/js/ground.js
+++ b/js/ground.js
@@ -62,7 +62,7 @@ export function updateGround(cameraX) {
 
   const fgCamera = cameraX * FOREGROUND_SPEED
   const fgOffset = fgCamera % FOREGROUND_WIDTH
-  const baseFg = Math.floor(cameraX / FOREGROUND_WIDTH) - 1
+  const baseFg = Math.floor(fgCamera / FOREGROUND_WIDTH) - 1
   foregroundElems.forEach((fg, i) => {
     const left = (baseFg + i) * FOREGROUND_WIDTH - fgOffset
     setCustomProperty(fg, "--left", left)

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,7 @@ import { setupWerewolves, updateWerewolves, getWerewolfElements } from './werewo
 import { getCustomProperty } from './updateCustomProperty.js'
 import { setupDivineKnight, walkOntoScreen } from './divineKnight.js'
 import { setupMana, updateMana } from './mana.js'
+import { showBossHealth, hideBossHealth } from './boss.js'
 
 const WORLD_WIDTH = 100
 const WORLD_HEIGHT = 30
@@ -206,6 +207,8 @@ function startBossFight() {
   combatMusic.currentTime = 0
   combatMusic.volume = 0.4
   combatMusic.play()
+  enableInput(true)
+  showBossHealth('Divine Knight Seraphiel')
   stopIdleLoop()
   lastTime = null
   window.requestAnimationFrame(update)
@@ -297,6 +300,7 @@ function handleStart() {
   bossTriggered = false
   worldElem.style.transform = 'translateX(0)'
   bossBg.classList.add('hide')
+  hideBossHealth()
   document.querySelectorAll('[data-background]').forEach(bg => bg.style.display = 'block')
   document.querySelectorAll('[data-midground]').forEach(mg => mg.style.display = '')
   document.querySelectorAll('[data-ground]').forEach(g => g.style.display = '')
@@ -341,6 +345,7 @@ function handleStart() {
 
 function handleLose() {
   isGameOver = true
+  hideBossHealth()
   setVampireLose()
   fireSound.play()
   deathSound.play()

--- a/js/projectile.js
+++ b/js/projectile.js
@@ -1,5 +1,7 @@
 import { getCustomProperty, setCustomProperty, incrementCustomProperty } from './updateCustomProperty.js'
 import { getWerewolfElements, damageWerewolf } from './werewolf.js'
+import { getKnightElement } from './divineKnight.js'
+import { damageBoss } from './boss.js'
 
 const PROJECTILE_SPEED = 0.1
 const FRAME_TIME = 100
@@ -54,6 +56,13 @@ export function updateProjectiles(delta, cameraX, worldWidth, crossRects) {
           return
         }
       }
+
+    const knight = getKnightElement()
+    if (knight && isCollision(knight.getBoundingClientRect(), projRect)) {
+      damageBoss(10)
+      proj.remove()
+      return
+    }
   
 
     if (worldX < cameraX - REMOVE_DISTANCE ||


### PR DESCRIPTION
## Summary
- correct foreground parallax calculation so layer never disappears
- add boss health UI and styling
- display boss health when fight starts and re-enable controls
- register projectile hits on the boss to drain health

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c7ca9db4c8322883a4aa0443cff34