### PR TITLE
Fix boss fight input freeze

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -210,6 +210,7 @@ function startBossFight() {
   enableInput(true)
   showBossHealth('Divine Knight Seraphiel')
   stopIdleLoop()
+  bossTriggered = false
   lastTime = null
   window.requestAnimationFrame(update)
 }


### PR DESCRIPTION
## Summary
- fix player controls not reactivating after boss cutscene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7ef441788322a2ae32785108b8ec