### PR TITLE
Fix boss arena boundaries and improve credits

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -564,6 +564,17 @@ body.shake {
   font-size: 5vmin;
 }
 
+.credit-content div {
+  margin: 2vmin 0;
+}
+
+.credit-title {
+  font-size: 8vmin;
+  margin-bottom: 3vmin;
+  color: crimson;
+  text-shadow: 0 0 5px black;
+}
+
 .restart-prompt {
   position: absolute;
   bottom: 5vmin;

--- a/index.html
+++ b/index.html
@@ -95,6 +95,7 @@
   <!-- 🎉 Credits Screen -->
   <div class="credit-screen hide" data-credit-screen>
     <div class="credit-content">
+      <div class="credit-title">Thank you for playing Carmilla: Blood Escape</div>
       <div>The game was created by Korshin Technologies</div>
       <div>Lead Developer: Seishin LeBlanc</div>
       <div>Tester: Koree Ryan</div>

--- a/js/divineKnight.js
+++ b/js/divineKnight.js
@@ -81,6 +81,19 @@ export function getKnightElement() {
   return knightElem
 }
 
+export function getKnightRect() {
+  if (!knightElem) return { left: 0, right: 0, top: 0, bottom: 0 }
+  const r = knightElem.getBoundingClientRect()
+  const insetX = r.width * 0.3
+  const insetY = r.height * 0.2
+  return {
+    left: r.left + insetX,
+    right: r.right - insetX,
+    top: r.top + insetY,
+    bottom: r.bottom
+  }
+}
+
 export function removeDivineKnight() {
   if (knightElem) {
     knightElem.remove()

--- a/js/main.js
+++ b/js/main.js
@@ -132,19 +132,31 @@ function update(time) {
 function updatePlayerAndCamera(delta) {
   updateVampire(delta, speedScale);
 
-  const x = getVampireX();
-  const halfW = WORLD_WIDTH / 2;
-  const leftBoundary  = cameraX + halfW - CAMERA_DEADZONE;
-  const rightBoundary = cameraX + halfW + CAMERA_DEADZONE;
+  let x = getVampireX();
 
-  if (x < leftBoundary) {
-    cameraX = x - (halfW - CAMERA_DEADZONE);
-  } else if (x > rightBoundary) {
-    cameraX = x - (halfW + CAMERA_DEADZONE);
+  if (bossActive) {
+    if (x < 0) {
+      setVampireLeft(0);
+      x = 0;
+    } else if (x > WORLD_WIDTH) {
+      setVampireLeft(WORLD_WIDTH);
+      x = WORLD_WIDTH;
+    }
+    cameraX = 0;
+  } else {
+    const halfW = WORLD_WIDTH / 2;
+    const leftBoundary  = cameraX + halfW - CAMERA_DEADZONE;
+    const rightBoundary = cameraX + halfW + CAMERA_DEADZONE;
+
+    if (x < leftBoundary) {
+      cameraX = x - (halfW - CAMERA_DEADZONE);
+    } else if (x > rightBoundary) {
+      cameraX = x - (halfW + CAMERA_DEADZONE);
+    }
+
+    // clamp so you don’t scroll beyond the level bounds
+    cameraX = Math.max(0, Math.min(cameraX, /* maxWorldWidth - viewportWidth */));
   }
-
-  // clamp so you don’t scroll beyond the level bounds
-  cameraX = Math.max(0, Math.min(cameraX, /* maxWorldWidth - viewportWidth */));
 
   // slide the entire world
   worldElem.style.transform = `translateX(${-cameraX}% )`;
@@ -405,12 +417,16 @@ function handleLose() {
 
 function handleBossDefeat() {
   bossActive = false
+  bossTriggered = true
   combatMusic.pause()
   combatMusic.currentTime = 0
   hideBossHealth()
   removeDivineKnight()
   heartContainer.classList.add('hide')
   manaContainer.classList.add('hide')
+  gameAreaElem.classList.add('hide')
+  worldElem.style.transform = 'translateX(0)'
+  cameraX = 0
   creditScreenElem.classList.remove('hide')
   document.addEventListener('keydown', restartFromCredits, { once: true })
   document.addEventListener('click', restartFromCredits, { once: true })

--- a/js/projectile.js
+++ b/js/projectile.js
@@ -1,6 +1,6 @@
 import { getCustomProperty, setCustomProperty, incrementCustomProperty } from './updateCustomProperty.js'
 import { getWerewolfElements, damageWerewolf } from './werewolf.js'
-import { getKnightElement } from './divineKnight.js'
+import { getKnightElement, getKnightRect } from './divineKnight.js'
 import { damageBoss } from './boss.js'
 
 const PROJECTILE_SPEED = 0.1
@@ -58,7 +58,7 @@ export function updateProjectiles(delta, cameraX, worldWidth, crossRects) {
       }
 
     const knight = getKnightElement()
-    if (knight && isCollision(knight.getBoundingClientRect(), projRect)) {
+    if (knight && isCollision(getKnightRect(), projRect)) {
       const dead = damageBoss(10)
       if (dead) document.dispatchEvent(new CustomEvent('bossDefeated'))
       proj.remove()


### PR DESCRIPTION
## Summary
- stop world updates once the boss is defeated and hide the arena
- keep the camera and player contained during the boss fight
- tighten Divine Knight collision box
- add title line and spacing to credits screen

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c88944174832281a81f03ecd5bb21