### PR TITLE
Fix boss UI layout and improve credits

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,8 +12,8 @@
 body {
   margin: 0;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  justify-content: flex-start;
+  align-items: flex-start;
   min-height: 100vh;
   background-color: rgb(17, 17, 17);
   overflow: hidden;
@@ -229,13 +229,14 @@ body {
   z-index: 999;
   font-family: VT323-Regular;
   color: crimson;
+  position: relative;
 }
 
 .boss-border {
   position: absolute;
-  top: -1vmin;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   width: 40vmin;
   pointer-events: none;
   z-index: -1;
@@ -556,6 +557,12 @@ body.shake {
   flex-direction: column;
   overflow: hidden;
   z-index: 1000;
+  opacity: 0;
+  transition: opacity 1s ease;
+}
+
+.credit-screen.fade-in {
+  opacity: 1;
 }
 
 .credit-content {
@@ -573,6 +580,11 @@ body.shake {
   margin-bottom: 3vmin;
   color: crimson;
   text-shadow: 0 0 5px black;
+}
+
+.credit-break {
+  font-size: 6vmin;
+  margin: 3vmin 0;
 }
 
 .restart-prompt {

--- a/index.html
+++ b/index.html
@@ -95,11 +95,18 @@
   <!-- 🎉 Credits Screen -->
   <div class="credit-screen hide" data-credit-screen>
     <div class="credit-content">
-      <div class="credit-title">Thank you for playing Carmilla: Blood Escape</div>
-      <div>The game was created by Korshin Technologies</div>
-      <div>Lead Developer: Seishin LeBlanc</div>
-      <div>Tester: Koree Ryan</div>
-      <div>Special thanks to Lucy Ryan</div>
+      <div class="credit-title">CARMILLA: BLOOD ESCAPE</div>
+      <div>A game by Korshin Technologies</div>
+      <div class="credit-break">⸻</div>
+      <div>Lead Developer</div>
+      <div>Seishin LeBlanc</div>
+      <div>Lead Test Engineer</div>
+      <div>Koree Ryan</div>
+      <div>Special Thanks</div>
+      <div>Lucy</div>
+      <div class="credit-break">⸻</div>
+      <div>Thank you for playing.</div>
+      <div>May the night remember you.</div>
     </div>
     <div class="restart-prompt blinking">Press Any Key To Restart</div>
   </div>

--- a/js/main.js
+++ b/js/main.js
@@ -428,6 +428,9 @@ function handleBossDefeat() {
   worldElem.style.transform = 'translateX(0)'
   cameraX = 0
   creditScreenElem.classList.remove('hide')
+  creditScreenElem.classList.remove('fade-in')
+  void creditScreenElem.offsetWidth
+  creditScreenElem.classList.add('fade-in')
   document.addEventListener('keydown', restartFromCredits, { once: true })
   document.addEventListener('click', restartFromCredits, { once: true })
   document.addEventListener('touchstart', restartFromCredits, { once: true })


### PR DESCRIPTION
## Summary
- align the boss UI border correctly
- show credit screen with fade-in animation and updated text
- left-align the viewport to stop boss arena boundary issues

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c8b7cb24c83229f2bb0257848883a