### PR TITLE
Fix boss UI alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,8 +12,8 @@
 body {
   margin: 0;
   display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
+  justify-content: center;
+  align-items: center;
   min-height: 100vh;
   background-color: rgb(17, 17, 17);
   overflow: hidden;
@@ -223,20 +223,23 @@ body {
   top: 2vmin;
   left: 50%;
   transform: translateX(-50%);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   z-index: 999;
   font-family: VT323-Regular;
   color: crimson;
+}
+
+.boss-container {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .boss-border {
   position: absolute;
-  top: 50%;
+  top: -1vmin;
   left: 50%;
-  transform: translate(-50%, -50%);
+  transform: translateX(-50%);
   width: 40vmin;
   pointer-events: none;
   z-index: -1;

--- a/index.html
+++ b/index.html
@@ -31,10 +31,12 @@
   </div>
   <!-- 🛡 Boss Health -->
   <div id="boss-health" class="boss-health hide">
-    <img src="assets/images/boss-ui-border.png" class="boss-border" alt="Boss UI Border" />
-    <div class="boss-name">Divine Knight Seraphiel</div>
-    <div class="boss-health-bar">
-      <div class="boss-health-fill" id="boss-health-fill"></div>
+    <div class="boss-container">
+      <img src="assets/images/boss-ui-border.png" class="boss-border" alt="Boss UI Border" />
+      <div class="boss-name">Divine Knight Seraphiel</div>
+      <div class="boss-health-bar">
+        <div class="boss-health-fill" id="boss-health-fill"></div>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- center the page layout again
- restore boss UI alignment
- wrap boss name and health bar in a new `.boss-container`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c8ebb53fc8322a90e8963ebd2eb78