### PR TITLE
Fix boss UI alignment and credit sequence

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -233,13 +233,15 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 40vmin;
+  padding: 1vmin 0;
 }
 
 .boss-border {
   position: absolute;
-  top: -1vmin;
+  top: 50%;
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -50%);
   width: 40vmin;
   pointer-events: none;
   z-index: -1;

--- a/js/main.js
+++ b/js/main.js
@@ -431,9 +431,11 @@ function handleBossDefeat() {
   creditScreenElem.classList.remove('fade-in')
   void creditScreenElem.offsetWidth
   creditScreenElem.classList.add('fade-in')
-  document.addEventListener('keydown', restartFromCredits, { once: true })
-  document.addEventListener('click', restartFromCredits, { once: true })
-  document.addEventListener('touchstart', restartFromCredits, { once: true })
+  setTimeout(() => {
+    document.addEventListener('keydown', restartFromCredits, { once: true })
+    document.addEventListener('click', restartFromCredits, { once: true })
+    document.addEventListener('touchstart', restartFromCredits, { once: true })
+  }, 300)
 }
 
 function restartFromCredits(e) {


### PR DESCRIPTION
## Summary
- adjust Divine Knight boss UI layout
- avoid immediate restart on boss defeat

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_684c91bf40f48322a7495f0acc98d75a