### PR TITLE
Fix layering and faster credit scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -240,6 +240,7 @@ body {
   padding: 1vmin 0;
 }
 
+
 .boss-border {
   position: absolute;
   top: 50%;
@@ -247,16 +248,20 @@ body {
   transform: translate(-50%, -50%);
   width: 55vmin;
   pointer-events: none;
-  z-index: -1;
+  z-index: 1;
 }
 
 .boss-name {
+  position: relative;
   font-size: 5vmin;
   margin-bottom: 1vmin;
   text-align: center;
+  z-index: 2;
 }
 
 .boss-health-bar {
+  position: relative;
+  z-index: 0;
   width: 50vmin;
   height: 2vmin;
   border: 2px solid crimson;
@@ -568,7 +573,7 @@ body.shake {
   overflow: hidden;
   z-index: 1000;
   opacity: 0;
-  transition: opacity 1s ease;
+  transition: opacity 0.4s ease;
 }
 
 .credit-screen.fade-in {


### PR DESCRIPTION
## Summary
- ensure boss health bar is under the border and the name is on top
- speed up credit fade-in so scroll starts quickly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ca1f410c883228a985294c94eb7f9