### PR TITLE
Update to use Divine Knight nameplate

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -251,11 +251,11 @@ body {
   z-index: 1;
 }
 
-.boss-name {
+.boss-nameplate {
   position: relative;
-  font-size: 5vmin;
   margin-bottom: 1vmin;
-  text-align: center;
+  width: 50vmin;
+  pointer-events: none;
   z-index: 2;
 }
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
   <div id="boss-health" class="boss-health hide">
     <div class="boss-container">
       <img src="assets/images/boss-ui-border.png" class="boss-border" alt="Boss UI Border" />
-      <div class="boss-name">Divine Knight<br>Seraphiel</div>
+      <img src="assets/images/UI/divine-knight-nameplate.PNG" class="boss-nameplate" alt="Divine Knight Seraphiel" />
     </div>
     <div class="boss-health-bar">
       <div class="boss-health-fill" id="boss-health-fill"></div>

--- a/js/boss.js
+++ b/js/boss.js
@@ -1,12 +1,10 @@
 const bossContainer = document.getElementById('boss-health');
 const bossFill = document.getElementById('boss-health-fill');
-const bossNameElem = bossContainer ? bossContainer.querySelector('.boss-name') : null;
 
 const MAX_HEALTH = 100;
 let currentHealth = MAX_HEALTH;
 
-export function showBossHealth(name = '') {
-  if (bossNameElem) bossNameElem.textContent = name;
+export function showBossHealth() {
   currentHealth = MAX_HEALTH;
   updateDisplay();
   if (bossContainer) bossContainer.classList.remove('hide');

--- a/js/main.js
+++ b/js/main.js
@@ -224,7 +224,7 @@ function startBossFight() {
   combatMusic.volume = 0.4
   combatMusic.play()
   enableInput(true)
-  showBossHealth('Divine Knight Seraphiel')
+  showBossHealth()
   stopIdleLoop()
   bossActive = true
   bossTriggered = false


### PR DESCRIPTION
## Summary
- swap text boss name for Divine Knight nameplate asset
- drop unused boss name text styles and JS logic

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_684cb9736c508322bdfa6cc2a328f4c7