### PR TITLE
Implement black credit fade and delayed title prompt

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -558,7 +558,7 @@ body.shake {
 .credit-screen {
   position: absolute;
   inset: 0;
-  background: url('../assets/images/backgrounds/credits-background-2.PNG') center/cover no-repeat;
+  background: black;
   color: crimson;
   font-family: VT323-Regular;
   display: flex;
@@ -569,6 +569,20 @@ body.shake {
   z-index: 1000;
   opacity: 0;
   transition: opacity 2s ease;
+}
+
+.credit-screen::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('../assets/images/backgrounds/credits-background-2.PNG') center/cover no-repeat;
+  opacity: 0;
+  transition: opacity 2s ease;
+  z-index: -1;
+}
+
+.credit-screen.show-bg::after {
+  opacity: 1;
 }
 
 .credit-screen.fade-in {
@@ -606,6 +620,12 @@ body.shake {
   position: absolute;
   bottom: 5vmin;
   font-size: 4vmin;
+  opacity: 0;
+  transition: opacity 2s ease;
+}
+
+.credit-screen.show-bg .restart-prompt {
+  opacity: 1;
 }
 
 @keyframes scrollCredits {

--- a/index.html
+++ b/index.html
@@ -95,7 +95,7 @@
 
   <!-- 🎉 Credits Screen -->
   <div class="credit-screen hide" data-credit-screen>
-    <div class="credit-content">
+    <div class="credit-content" data-credit-content>
       <div class="credit-title">CARMILLA: BLOOD ESCAPE</div>
       <div>A game by Korshin Technologies</div>
       <div class="credit-break">⸻</div>
@@ -129,7 +129,7 @@
       <div>Thank you for playing.</div>
       <div>The night is watching.</div>
     </div>
-    <div class="restart-prompt blinking">Press Any Key To Restart</div>
+    <div class="restart-prompt blinking" data-restart-prompt>Press Any Key To Return To Title Screen</div>
   </div>
 
   <!-- 🖤 Dialogue Background -->

--- a/js/main.js
+++ b/js/main.js
@@ -50,6 +50,8 @@ const speakerNameElem = document.getElementById('speaker-name')
 const bossBg = document.getElementById('boss-bg')
 const controlsScreenElem = document.querySelector('[data-controls-screen]')
 const creditScreenElem = document.querySelector('[data-credit-screen]')
+const creditContentElem = document.querySelector('[data-credit-content]')
+const restartPromptElem = document.querySelector('[data-restart-prompt]')
 
 let lastTime
 let speedScale
@@ -430,6 +432,10 @@ function handleBossDefeat() {
   gameAreaElem.classList.add('hide')
   worldElem.style.transform = 'translateX(0)'
   cameraX = 0
+  creditScreenElem.classList.remove('show-bg')
+  creditContentElem.style.animation = 'none'
+  void creditContentElem.offsetWidth
+  creditContentElem.style.animation = ''
   creditScreenElem.classList.remove('hide')
   creditScreenElem.classList.remove('fade-in')
   void creditScreenElem.offsetWidth
@@ -439,15 +445,19 @@ function handleBossDefeat() {
     heartbeat.volume = 0.5
     heartbeat.play()
   }
-  setTimeout(() => {
+
+  const onCreditsEnd = () => {
+    creditScreenElem.classList.add('show-bg')
     document.addEventListener('keydown', restartFromCredits, { once: true })
     document.addEventListener('click', restartFromCredits, { once: true })
     document.addEventListener('touchstart', restartFromCredits, { once: true })
-  }, 300)
+  }
+  creditContentElem.addEventListener('animationend', onCreditsEnd, { once: true })
 }
 
 function restartFromCredits(e) {
   if (e) e.preventDefault()
+  creditScreenElem.classList.remove('show-bg')
   creditScreenElem.classList.add('hide')
   heartbeat.pause()
   heartbeat.currentTime = 0


### PR DESCRIPTION
## Summary
- show credits over a black screen
- fade in credits background after the scroll completes
- reveal a blinking prompt to return to the title screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cc52ffc5c8322a2ec39253cdbb58d