### PR TITLE
Adjust credits delay and boss health position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,7 +224,7 @@ body {
 
 .boss-health {
   position: fixed;
-  top: -12vmin;
+  top: 8vmin;
   left: 50%;
   transform: translateX(-50%);
   z-index: 999;

--- a/js/main.js
+++ b/js/main.js
@@ -447,10 +447,12 @@ function handleBossDefeat() {
   }
 
   const onCreditsEnd = () => {
-    creditScreenElem.classList.add('show-bg')
-    document.addEventListener('keydown', restartFromCredits, { once: true })
-    document.addEventListener('click', restartFromCredits, { once: true })
-    document.addEventListener('touchstart', restartFromCredits, { once: true })
+    setTimeout(() => {
+      creditScreenElem.classList.add('show-bg')
+      document.addEventListener('keydown', restartFromCredits, { once: true })
+      document.addEventListener('click', restartFromCredits, { once: true })
+      document.addEventListener('touchstart', restartFromCredits, { once: true })
+    }, 50000)
   }
   creditContentElem.addEventListener('animationend', onCreditsEnd, { once: true })
 }


### PR DESCRIPTION
## Summary
- keep boss health bar visible by lowering it
- delay credits background for 50 seconds after credits end

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cc742880c8322b920f6f914f46278