### PR TITLE
Fix credit timing and boss UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,7 +224,7 @@ body {
 
 .boss-health {
   position: fixed;
-  top: 8vmin;
+  top: 20vmin;
   left: 50%;
   transform: translateX(-50%);
   z-index: 999;
@@ -624,7 +624,7 @@ body.shake {
   transition: opacity 2s ease;
 }
 
-.credit-screen.show-bg .restart-prompt {
+.credit-screen.show-prompt .restart-prompt {
   opacity: 1;
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -328,6 +328,7 @@ function handleStart() {
   heartbeat.currentTime = 0
   removeDivineKnight()
   creditScreenElem.classList.add('hide')
+  creditScreenElem.classList.remove('show-prompt')
   document.querySelectorAll('[data-background]').forEach(bg => bg.style.display = 'block')
   document.querySelectorAll('[data-midground]').forEach(mg => mg.style.display = '')
   document.querySelectorAll('[data-ground]').forEach(g => g.style.display = '')
@@ -433,6 +434,7 @@ function handleBossDefeat() {
   worldElem.style.transform = 'translateX(0)'
   cameraX = 0
   creditScreenElem.classList.remove('show-bg')
+  creditScreenElem.classList.remove('show-prompt')
   creditContentElem.style.animation = 'none'
   void creditContentElem.offsetWidth
   creditContentElem.style.animation = ''
@@ -449,10 +451,13 @@ function handleBossDefeat() {
   const onCreditsEnd = () => {
     setTimeout(() => {
       creditScreenElem.classList.add('show-bg')
-      document.addEventListener('keydown', restartFromCredits, { once: true })
-      document.addEventListener('click', restartFromCredits, { once: true })
-      document.addEventListener('touchstart', restartFromCredits, { once: true })
-    }, 50000)
+      setTimeout(() => {
+        creditScreenElem.classList.add('show-prompt')
+        document.addEventListener('keydown', restartFromCredits, { once: true })
+        document.addEventListener('click', restartFromCredits, { once: true })
+        document.addEventListener('touchstart', restartFromCredits, { once: true })
+      }, 2000)
+    }, 37500)
   }
   creditContentElem.addEventListener('animationend', onCreditsEnd, { once: true })
 }
@@ -460,6 +465,7 @@ function handleBossDefeat() {
 function restartFromCredits(e) {
   if (e) e.preventDefault()
   creditScreenElem.classList.remove('show-bg')
+  creditScreenElem.classList.remove('show-prompt')
   creditScreenElem.classList.add('hide')
   heartbeat.pause()
   heartbeat.currentTime = 0


### PR DESCRIPTION
## Summary
- reposition boss health overlay lower on screen
- delay credit background and restart prompt slightly less
- show restart prompt after background fade-in

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684cd669220083228424969e34e9ab4d