### PR TITLE
Fix credits and adjust gameplay balance

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -256,7 +256,7 @@ body {
 
 .boss-health-bar {
   position: relative;
-  z-index: 0;
+  z-index: 3;
   width: 45vmin;
   height: 2vmin;
   border: 2px solid crimson;

--- a/js/divineKnight.js
+++ b/js/divineKnight.js
@@ -3,8 +3,8 @@ import { getVampireX } from './vampire.js'
 
 const gameAreaElem = document.querySelector('[data-game-area]')
 
-const WALK_SPEED = 0.03
-const MOVE_SPEED = 0.02
+const WALK_SPEED = 0.015
+const MOVE_SPEED = 0.01
 const WALK_FRAME_COUNT = 8
 const WALK_FRAME_TIME = 100
 const IDLE_FRAME_COUNT = 4

--- a/js/main.js
+++ b/js/main.js
@@ -23,7 +23,7 @@ import { showBossHealth, hideBossHealth } from './boss.js'
 const WORLD_WIDTH = 100
 const WORLD_HEIGHT = 30
 const SPEED_SCALE_INCREASE = 0.00001
-const MAX_HEARTS = 5
+const MAX_HEARTS = 6
 const CAMERA_DEADZONE = 5  // how far from center before camera scrolls
 
 const worldElem = document.querySelector('[data-world]')
@@ -462,15 +462,13 @@ function handleBossDefeat() {
   }
 
   const onCreditsEnd = () => {
+    creditScreenElem.classList.add('show-bg')
     setTimeout(() => {
-      creditScreenElem.classList.add('show-bg')
-      setTimeout(() => {
-        creditScreenElem.classList.add('show-prompt')
-        document.addEventListener('keydown', restartFromCredits, { once: true })
-        document.addEventListener('click', restartFromCredits, { once: true })
-        document.addEventListener('touchstart', restartFromCredits, { once: true })
-      }, 2000)
-    }, 37500)
+      creditScreenElem.classList.add('show-prompt')
+      document.addEventListener('keydown', restartFromCredits, { once: true })
+      document.addEventListener('click', restartFromCredits, { once: true })
+      document.addEventListener('touchstart', restartFromCredits, { once: true })
+    }, 2000)
   }
   creditContentElem.addEventListener('animationend', onCreditsEnd, { once: true })
 }


### PR DESCRIPTION
## Summary
- slow down Divine Knight movement
- increase player hearts to 6
- show boss health bar above nameplate
- show credits background and prompt immediately after scroll finishes

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684cdcbe9aec8322bca93e3880ad0c5e