### PR TITLE
Fix boss UI alignment and refine boss hit detection

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -248,7 +248,7 @@ body {
 
 .boss-nameplate {
   position: relative;
-  margin-bottom: -2vmin;
+  margin-bottom: 1vmin;
   width: 60vmin;
   pointer-events: none;
   z-index: 2;

--- a/js/divineKnight.js
+++ b/js/divineKnight.js
@@ -190,7 +190,7 @@ export function getKnightRect() {
   if (!knightElem) return { left: 0, right: 0, top: 0, bottom: 0 }
   const r = knightElem.getBoundingClientRect()
   const insetX = r.width * 0.45
-  const insetY = r.height * 0.3
+  const insetY = r.height * 0.45
   return {
     left: r.left + insetX,
     right: r.right - insetX,

--- a/js/main.js
+++ b/js/main.js
@@ -15,8 +15,7 @@ import {
 import { setupCross, updateCross, getCrossRects } from './cross.js'
 import { setupProjectiles, updateProjectiles } from './projectile.js'
 import { setupWerewolves, updateWerewolves, getWerewolfElements } from './werewolf.js'
-import { getCustomProperty } from './updateCustomProperty.js'
-import { setupDivineKnight, walkOntoScreen, removeDivineKnight, startKnightAI, getKnightElement } from './divineKnight.js'
+import { setupDivineKnight, walkOntoScreen, removeDivineKnight, startKnightAI, getKnightElement, getKnightRect } from './divineKnight.js'
 import { setupMana, updateMana } from './mana.js'
 import { showBossHealth, hideBossHealth } from './boss.js'
 
@@ -188,9 +187,9 @@ function checkKnightCollision() {
   if (!state || !state.startsWith('attack')) return false
   const frame = Number(knight.dataset.frame)
   if (frame < 2) return false
-  const range = state === 'attack3' ? 15 : 10
-  const distance = Math.abs(getCustomProperty(knight, '--left') - getVampireX())
-  return distance <= range
+  const knightRect = getKnightRect()
+  const vampireRect = getVampireRect()
+  return isCollision(knightRect, vampireRect)
 }
 
 function isCollision(r1, r2) {


### PR DESCRIPTION
## Summary
- adjust boss nameplate CSS so it sits above the health bar
- shrink Divine Knight vertical hitbox
- only check for boss attacks using bounding box collision

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ce64a23d483228998dc999b754a2d