### PR TITLE
Adjust jump height and boss UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,7 +224,7 @@ body {
 
 .boss-health {
   position: fixed;
-  top: 8vmin;
+  top: 2vmin;
   left: 50%;
   transform: translateX(-50%);
   z-index: 999;

--- a/js/vampire.js
+++ b/js/vampire.js
@@ -11,7 +11,7 @@ import { spendMana } from './mana.js'
 const manaBarElem = document.querySelector('.mana-bar')
   
   const vampireElem = document.querySelector('[data-vampire]')
-  const JUMP_SPEED = 0.45
+  const JUMP_SPEED = 0.54
   const GRAVITY = 0.0015
   const MOVE_SPEED = 0.02
   const JUMP_SPEED_MULT = 1.8


### PR DESCRIPTION
## Summary
- raise jump speed 20% so the player can leap over the boss
- move the boss nameplate higher on the screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ce7b56acc83229c4b1b3c343b1e42