### PR TITLE
Fix credits timing and boss HUD

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -224,7 +224,7 @@ body {
 
 .boss-health {
   position: fixed;
-  top: 2vmin;
+  top: -2vmin;
   left: 50%;
   transform: translateX(-50%);
   z-index: 999;
@@ -577,7 +577,7 @@ body.shake {
   inset: 0;
   background: url('../assets/images/backgrounds/credits-background-2.PNG') center/cover no-repeat;
   opacity: 0;
-  transition: opacity 2s ease;
+  transition: opacity 1s ease;
   z-index: -1;
 }
 
@@ -590,7 +590,7 @@ body.shake {
 }
 
 .credit-content {
-  animation: scrollCredits 60s linear forwards;
+  animation: scrollCredits 45s linear forwards;
   text-align: center;
   font-size: 5vmin;
 }

--- a/js/divineKnight.js
+++ b/js/divineKnight.js
@@ -27,7 +27,7 @@ const ATTACK_RANGE = 10
 const ATTACK3_RANGE = 15
 const RUN_ATTACK_DISTANCE = 20
 const RUN_ATTACK_SPEED = 0.03
-const DEFEND_CHANCE = 0.2
+const DEFEND_CHANCE = 0.25
 
 let knightElem
 let walkFrame = 0


### PR DESCRIPTION
## Summary
- raise boss health UI higher so the top is clipped by the screen
- show the credits background sooner and speed up the scroll
- make the divine knight guard slightly more often

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cedca14ac8322beab65f1d768a9ad