### PR TITLE
Adjust divine knight cutscene animations

### DIFF
--- a/js/divineKnight.js
+++ b/js/divineKnight.js
@@ -353,13 +353,7 @@ export function startDying(callback) {
   knightElem.style.transform = dir === -1 ? 'scaleX(-1)' : 'scaleX(1)'
   knightElem.dataset.state = 'dead'
   setKnightDyingFrame(0)
-  setTimeout(() => {
-    setKnightDyingFrame(1)
-    setTimeout(() => {
-      setKnightDyingFrame(2)
-      if (callback) callback()
-    }, DYING_FRAME_TIME)
-  }, DYING_FRAME_TIME)
+  if (callback) setTimeout(callback, DYING_FRAME_TIME * 2)
 }
 
 export function removeDivineKnight() {

--- a/js/main.js
+++ b/js/main.js
@@ -505,20 +505,21 @@ async function playBossCutscene() {
   stopIdleLoop()
 
   await new Promise(res => startDying(res))
+  setKnightDyingFrame(1)
   await runDialogue(bossDeath1, false)
 
   await moveVampireTo(60)
   await runDialogue(bossDeath2, false)
 
-  setKnightDyingFrame(3)
+  setKnightDyingFrame(2)
   await runDialogue(bossDeath3, false)
 
-  setKnightDyingFrame(2)
+  setKnightDyingFrame(1)
   await runDialogue(bossDeath4, false)
 
   lightOverlay.classList.add('fade-in')
   await delay(1000)
-  setKnightDyingFrame(1)
+  setKnightDyingFrame(0)
   await runDialogue(bossDeath5, false)
 
   lightOverlay.classList.add('flash')


### PR DESCRIPTION
## Summary
- refine divine knight death animation timing
- step through death frames manually in cutscene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684da923bd6483228a2853cc1b630237