### PR TITLE
Add heart drops and adjust credits

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -163,6 +163,16 @@ body {
   visibility: hidden;
 }
 
+.pickup-heart {
+  --left: 0;
+  position: absolute;
+  width: 6vmin;
+  bottom: 0;
+  left: calc(var(--left) * 1%);
+  z-index: 3;
+  visibility: hidden;
+}
+
 
 .game-area .midground,
 .game-area .ground,
@@ -170,7 +180,8 @@ body {
 .game-area .cross,
 .game-area .projectile,
 .game-area .werewolf,
-.game-area .divine-knight {
+.game-area .divine-knight,
+.game-area .pickup-heart {
   visibility: visible;
 }
 
@@ -611,7 +622,7 @@ body.shake {
 }
 
 .credit-content {
-  animation: scrollCredits 35s linear forwards;
+  animation: scrollCredits 45s linear forwards;
   text-align: center;
   font-size: 5vmin;
 }
@@ -651,7 +662,7 @@ body.shake {
 
 @keyframes scrollCredits {
   from { transform: translateY(100%); }
-  to { transform: translateY(-100%); }
+  to { transform: translateY(-110%); }
 }
 
 

--- a/js/hearts.js
+++ b/js/hearts.js
@@ -1,0 +1,34 @@
+import { getCustomProperty, setCustomProperty } from './updateCustomProperty.js'
+
+const gameAreaElem = document.querySelector('[data-game-area]')
+const REMOVE_DISTANCE = 20
+
+export function setupHearts() {
+  document.querySelectorAll('[data-heart]').forEach(h => h.remove())
+}
+
+export function spawnHeart(worldX) {
+  const heart = document.createElement('img')
+  heart.dataset.heart = true
+  heart.dataset.worldX = worldX
+  heart.src = 'assets/images/heart-full.png'
+  heart.classList.add('pickup-heart')
+  setCustomProperty(heart, '--left', worldX)
+  setCustomProperty(heart, '--bottom', 0)
+  gameAreaElem.append(heart)
+}
+
+export function updateHearts(cameraX, worldWidth) {
+  document.querySelectorAll('[data-heart]').forEach(h => {
+    const x = Number(h.dataset.worldX)
+    if (x < cameraX - REMOVE_DISTANCE || x > cameraX + worldWidth + REMOVE_DISTANCE) {
+      h.remove()
+    } else {
+      setCustomProperty(h, '--left', x)
+    }
+  })
+}
+
+export function getHeartElements() {
+  return document.querySelectorAll('[data-heart]')
+}

--- a/js/main.js
+++ b/js/main.js
@@ -18,6 +18,7 @@ import { setupWerewolves, updateWerewolves, getWerewolfElements } from './werewo
 import { setupDivineKnight, walkOntoScreen, removeDivineKnight, startKnightAI, getKnightElement, getKnightRect, getKnightAttackRect, startDying, setKnightDyingFrame, getKnightX } from './divineKnight.js'
 import { setupMana, updateMana } from './mana.js'
 import { showBossHealth, hideBossHealth } from './boss.js'
+import { setupHearts, updateHearts, getHeartElements } from './hearts.js'
 
 const WORLD_WIDTH = 100
 const WORLD_HEIGHT = 30
@@ -134,6 +135,7 @@ function update(time) {
   updateCross(cameraX)
   updateWerewolves(delta, speedScale, cameraX, WORLD_WIDTH, getVampireX(), bossActive)
   updateProjectiles(delta, cameraX, WORLD_WIDTH, getCrossRects())
+  updateHearts(cameraX, WORLD_WIDTH)
   updateSpeedScale(delta)
   updateDistance()
   updateMana(delta)
@@ -141,6 +143,7 @@ function update(time) {
   if (!isInvincible && (checkCrossCollision() || checkWerewolfCollision() || checkKnightCollision())) {
     removeHeart()
   }
+  checkHeartPickup()
 
   if (currentHearts <= 0) {
     if (!isGameOver) handleLose()
@@ -241,7 +244,7 @@ function updateDistance() {
 }
 
 function triggerBossEncounter() {
-  startDialogue(bossDialogueLines, startBossFight, false, false)
+  startDialogue(bossDialogueLines, startBossFight, false, true)
 }
 
 function startBossTransition() {
@@ -383,6 +386,7 @@ function handleStart() {
   setupCross()
   setupWerewolves()
   setupProjectiles()
+  setupHearts()
 
   // Hide title splash & show backgrounds
   document.getElementById('title-bg').style.display = 'none'
@@ -611,6 +615,22 @@ function updateHeartDisplay() {
     heart.classList.add('heart')
     if (i < currentHearts) heart.classList.add('full-heart')
     heartContainer.appendChild(heart)
+  }
+}
+
+function addHeart() {
+  if (currentHearts >= MAX_HEARTS) return
+  currentHearts++
+  updateHeartDisplay()
+}
+
+function checkHeartPickup() {
+  const vampireRect = getVampireRect()
+  for (const heart of getHeartElements()) {
+    if (isCollision(heart.getBoundingClientRect(), vampireRect)) {
+      heart.remove()
+      addHeart()
+    }
   }
 }
 

--- a/js/werewolf.js
+++ b/js/werewolf.js
@@ -1,4 +1,5 @@
 import { getCustomProperty, setCustomProperty, incrementCustomProperty } from './updateCustomProperty.js'
+import { spawnHeart } from './hearts.js'
 
 const gameAreaElem = document.querySelector('[data-game-area]')
 
@@ -121,6 +122,9 @@ function updateWolf(wolf, delta, speedScale, cameraX, worldWidth, vampireX) {
       if (frameTime >= DEAD_FRAME_TIME) {
         frame++
         if (frame >= DEAD_FRAME_COUNT) {
+          if (wolf.dataset.dropHeart === '1') {
+            spawnHeart(getCustomProperty(wolf, '--left'))
+          }
           wolf.remove()
           return
         } else {
@@ -158,6 +162,7 @@ export function damageWerewolf(wolf) {
   wolf.dataset.hits = hits
   if (hits >= 3) {
     wolf.dataset.state = 'dead'
+    wolf.dataset.dropHeart = Math.random() < 0.3 ? '1' : '0'
     wolf.dataset.frame = 0
     wolf.dataset.frameTime = 0
     wolf.src = 'assets/images/white-werewolf/white-werewolf-dead/white-werewolf-dead000.png'


### PR DESCRIPTION
## Summary
- hearts can drop from werewolves and heal Carmilla
- show heart pickups in the game area
- restore dialogue music during boss intro
- slow down credits scroll to 45s and tighten background fade timing

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dae88c59883229b2b3601ad89a0fb