### PR TITLE
Add pulsing heart drops and essence warning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -165,12 +165,31 @@ body {
 
 .pickup-heart {
   --left: 0;
+  --bottom: 5;
   position: absolute;
-  width: 6vmin;
-  bottom: 0;
+  width: 8vmin;
+  bottom: calc(var(--bottom) * 1%);
   left: calc(var(--left) * 1%);
   z-index: 3;
   visibility: hidden;
+  transform-origin: center;
+  animation: pulse 0.8s infinite;
+}
+
+.essence-warning {
+  --left: 0;
+  --bottom: 0;
+  position: absolute;
+  color: crimson;
+  font-family: VT323-Regular;
+  font-size: 4vmin;
+  left: calc(var(--left) * 1%);
+  bottom: calc(var(--bottom) * 1%);
+  transform: translate(-50%, 0);
+  text-shadow: 0 0 2px black;
+  pointer-events: none;
+  z-index: 6;
+  animation: floatText 1s forwards;
 }
 
 
@@ -181,7 +200,8 @@ body {
 .game-area .projectile,
 .game-area .werewolf,
 .game-area .divine-knight,
-.game-area .pickup-heart {
+.game-area .pickup-heart,
+.game-area .essence-warning {
   visibility: visible;
 }
 
@@ -410,6 +430,16 @@ body {
   0%, 100% { transform: translate(0, 0); }
   20%, 60% { transform: translate(-3px, 0); }
   40%, 80% { transform: translate(3px, 0); }
+}
+
+@keyframes pulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.2); }
+}
+
+@keyframes floatText {
+  from { opacity: 1; transform: translate(-50%, 0); }
+  to { opacity: 0; transform: translate(-50%, 2vmin); }
 }
 
 body.shake {

--- a/js/hearts.js
+++ b/js/hearts.js
@@ -14,7 +14,7 @@ export function spawnHeart(worldX) {
   heart.src = 'assets/images/heart-full.png'
   heart.classList.add('pickup-heart')
   setCustomProperty(heart, '--left', worldX)
-  setCustomProperty(heart, '--bottom', 0)
+  setCustomProperty(heart, '--bottom', 5)
   gameAreaElem.append(heart)
 }
 

--- a/js/vampire.js
+++ b/js/vampire.js
@@ -8,6 +8,8 @@ import {
 import { createProjectile } from './projectile.js'
 import { spendMana } from './mana.js'
 
+const gameAreaElem = document.querySelector('[data-game-area]')
+
 const manaBarElem = document.querySelector('.mana-bar')
   
   const vampireElem = document.querySelector('[data-vampire]')
@@ -24,6 +26,13 @@ const manaBarElem = document.querySelector('.mana-bar')
   const IDLE_FRAME_TIME = 100
   const ATTACK_FRAME_COUNT = 6
   const ATTACK_FRAME_TIME = 100
+
+  const ESSENCE_MESSAGES = [
+    "I don't have enough essence.",
+    "I can't do that right now.",
+    "My life force is running thin.",
+    "I need more vampiric essence."
+  ]
   
   let isJumping
   let isAttacking
@@ -218,6 +227,7 @@ const manaBarElem = document.querySelector('.mana-bar')
         void manaBarElem.offsetWidth
         manaBarElem.classList.add('shake')
       }
+      showEssenceWarning()
       return
     }
     isAttacking = true
@@ -273,6 +283,18 @@ const manaBarElem = document.querySelector('.mana-bar')
       moveDirection = 0
       inputEnabled = false
     }
+  }
+
+  function showEssenceWarning() {
+    const msg = ESSENCE_MESSAGES[Math.floor(Math.random() * ESSENCE_MESSAGES.length)]
+    const text = document.createElement('div')
+    text.textContent = msg
+    text.dataset.warning = true
+    text.classList.add('essence-warning')
+    setCustomProperty(text, '--left', getVampireLeft() + 5)
+    setCustomProperty(text, '--bottom', getCustomProperty(vampireElem, '--bottom') + 25)
+    gameAreaElem.append(text)
+    text.addEventListener('animationend', () => text.remove())
   }
 
 

--- a/js/werewolf.js
+++ b/js/werewolf.js
@@ -162,7 +162,7 @@ export function damageWerewolf(wolf) {
   wolf.dataset.hits = hits
   if (hits >= 3) {
     wolf.dataset.state = 'dead'
-    wolf.dataset.dropHeart = Math.random() < 0.3 ? '1' : '0'
+    wolf.dataset.dropHeart = Math.random() < 0.6 ? '1' : '0'
     wolf.dataset.frame = 0
     wolf.dataset.frameTime = 0
     wolf.src = 'assets/images/white-werewolf/white-werewolf-dead/white-werewolf-dead000.png'


### PR DESCRIPTION
## Summary
- double the drop rate of hearts from wolves
- make dropped hearts bigger and pulsing
- raise hearts slightly off the ground
- show random essence warning text when attacking without mana

## Testing
- `npm test` *(fails: no `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684db529ed888322b7a5dadbd81b5402