### PR TITLE
Improve essence warning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -183,6 +183,8 @@ body {
   color: crimson;
   font-family: VT323-Regular;
   font-size: 4vmin;
+  width: 22vmin;
+  text-align: center;
   left: calc(var(--left) * 1%);
   bottom: calc(var(--bottom) * 1%);
   transform: translate(-50%, 0);

--- a/js/vampire.js
+++ b/js/vampire.js
@@ -50,6 +50,7 @@ const manaBarElem = document.querySelector('.mana-bar')
   let inputEnabled = false
   let idleLoopId = null
   let idleLastTime = null
+  let essenceWarningActive = false
   
   export function setupVampire() {
     isJumping = false
@@ -286,6 +287,7 @@ const manaBarElem = document.querySelector('.mana-bar')
   }
 
   function showEssenceWarning() {
+    if (essenceWarningActive) return
     const msg = ESSENCE_MESSAGES[Math.floor(Math.random() * ESSENCE_MESSAGES.length)]
     const text = document.createElement('div')
     text.textContent = msg
@@ -294,7 +296,11 @@ const manaBarElem = document.querySelector('.mana-bar')
     setCustomProperty(text, '--left', getVampireLeft() + 5)
     setCustomProperty(text, '--bottom', getCustomProperty(vampireElem, '--bottom') + 25)
     gameAreaElem.append(text)
-    text.addEventListener('animationend', () => text.remove())
+    essenceWarningActive = true
+    text.addEventListener('animationend', () => {
+      text.remove()
+      essenceWarningActive = false
+    })
   }
 
 


### PR DESCRIPTION
## Summary
- enlarge essence warning area so text wraps more naturally
- prevent overlapping essence warnings when spamming attacks

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dbc1999bc83229271e375fc992417