### PR TITLE
Fix viewport alignment for backgrounds

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,7 +82,7 @@ body {
 
 .midground {
   --left: 0;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: calc(var(--left) * 1vw);
   width: 50vw;
@@ -96,7 +96,7 @@ body {
 
 .ground {
   --left: 0;
-  position: absolute;
+  position: fixed;
   width: 100vw;
   height: 15vh;
   bottom: 0;

--- a/js/ground.js
+++ b/js/ground.js
@@ -40,7 +40,7 @@ export function updateGround(cameraX) {
   const groundOffset = cameraX % GROUND_WIDTH
   const baseGround = Math.floor(cameraX / GROUND_WIDTH)
   groundElems.forEach((ground, i) => {
-    const left = (baseGround + i) * GROUND_WIDTH - groundOffset
+    const left = (baseGround + i) * GROUND_WIDTH - groundOffset - cameraX
     setCustomProperty(ground, "--left", left)
   })
 
@@ -48,7 +48,7 @@ export function updateGround(cameraX) {
   const midOffset = midCamera % MIDGROUND_WIDTH
   const baseMid = Math.floor(midCamera / MIDGROUND_WIDTH)
   midgroundElems.forEach((mg, i) => {
-    const left = (baseMid + i) * MIDGROUND_WIDTH - midOffset // parallax speed
+    const left = (baseMid + i) * MIDGROUND_WIDTH - midOffset - cameraX
     setCustomProperty(mg, "--left", left)
   })
 


### PR DESCRIPTION
## Summary
- set `midground` and `ground` layers to use `position: fixed`
- offset their movement by the camera in `updateGround`

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684e04ed64208322af31fd3f90630366