### PR TITLE
Fix Divine Retribution SFX trigger

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -664,7 +664,10 @@ function startDialogue(lines, onComplete, withBg = true, playMusic = true) {
 
 function showDialogueLine(index) {
   const line = dialogueLines[index]
-  if (line.text.toUpperCase().includes('RETRIBUTION') && retributionSound) {
+  if (
+    retributionSound &&
+    line.text.trim().toUpperCase() === 'DIVINE....'
+  ) {
     retributionSound.currentTime = 0
     retributionSound.play()
   }


### PR DESCRIPTION
## Summary
- trigger Divine Retribution SFX only when the dialogue line is `Divine....`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e1e864bac8322be25807254344f47