### PR TITLE
Add new boss defeat music and werewolf growls

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,8 @@
   <audio loop id="heartbeat" src="assets/sounds/music/Heartbeat.m4a"></audio>
   <audio id="blood-project-sound" src="assets/sounds/sfx/blood-projectile-sound.mp3"></audio>
   <audio id="divine-retribution-sfx" src="assets/sounds/sfx/divine-retribution-sound-effect.mp3"></audio>
+  <audio id="wolf-growls" src="assets/sounds/sfx/wolf-snarls-and-growls.mp3"></audio>
+  <audio id="divine-knight-dying-music" src="assets/sounds/music/divine-knight-dying-music.mp3"></audio>
 
   <!-- 💥 Effects -->
   <div id="screen-flash"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -38,6 +38,7 @@ const gameOverMusic = document.querySelector('[data-gameovermusic]')
 const combatMusic = document.querySelector('[data-combatmusic]')
 const heartbeat = document.getElementById('heartbeat')
 const retributionSound = document.getElementById('divine-retribution-sfx')
+const knightDyingMusic = document.getElementById('divine-knight-dying-music')
 const heartContainer = document.querySelector('[data-hearts]')
 const manaContainer = document.querySelector('.mana-container')
 const screenFlash = document.getElementById('screen-flash')
@@ -360,6 +361,10 @@ function handleStart() {
   hideBossHealth()
   combatMusic.pause()
   combatMusic.currentTime = 0
+  if (knightDyingMusic) {
+    knightDyingMusic.pause()
+    knightDyingMusic.currentTime = 0
+  }
   heartbeat.pause()
   heartbeat.currentTime = 0
   removeDivineKnight()
@@ -507,6 +512,11 @@ async function playBossCutscene() {
   enableInput(false)
   setMoveDirection(0)
   stopIdleLoop()
+  if (knightDyingMusic && knightDyingMusic.paused) {
+    knightDyingMusic.currentTime = 0
+    knightDyingMusic.volume = 0.4
+    knightDyingMusic.play()
+  }
 
   await new Promise(res => startDying(res))
   setKnightDyingFrame(1)
@@ -533,6 +543,11 @@ async function playBossCutscene() {
   await delay(1500)
   lightOverlay.classList.remove('flash')
   lightOverlay.classList.remove('fade-in')
+
+  if (knightDyingMusic) {
+    knightDyingMusic.pause()
+    knightDyingMusic.currentTime = 0
+  }
 
   showCreditsScreen()
 }

--- a/js/werewolf.js
+++ b/js/werewolf.js
@@ -16,6 +16,8 @@ const HURT_FRAME_COUNT = 2
 const HURT_FRAME_TIME = 100
 const DEAD_FRAME_COUNT = 2
 const DEAD_FRAME_TIME = 200
+const wolfGrowlSound = document.getElementById('wolf-growls')
+if (wolfGrowlSound) wolfGrowlSound.volume = 0.4
 
 let nextSpawnTime = SPAWN_INTERVAL_MIN
 
@@ -61,6 +63,10 @@ function spawnWerewolf(cameraX, worldWidth) {
 
   wolf.src = 'assets/images/white-werewolf/white-werewolf-running/white-werewolf-running000.png'
   gameAreaElem.append(wolf)
+  if (wolfGrowlSound && Math.random() < 0.3) {
+    wolfGrowlSound.currentTime = 0
+    wolfGrowlSound.play()
+  }
 }
 
 function updateWolf(wolf, delta, speedScale, cameraX, worldWidth, vampireX) {


### PR DESCRIPTION
## Summary
- add `wolf-growls` and `divine-knight-dying-music` audio tags
- play random wolf growls when werewolves spawn
- start/stop divine knight death music during boss defeat cutscene
- stop death music on restart

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684e41fb8f288322be69c7778742ef87