### PR TITLE
Fix credits spacing, stop werewolf growls on boss entry, remove vibrate freeze

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
       <div class="credit-role">Production &amp; Direction</div>
       <div class="credit-name">Seishin LeBlanc</div>
       <div class="credit-role">Original Music</div>
-      <div class="credit-name">“Heartbeat” – code VAMPIRE</div>
+      <div class="credit-name copyrightprior">“Heartbeat” – code VAMPIRE</div>
       <div class="credit-name copyrightprior">“Bloodrave” – code VAMPIRE</div>
       <div class="credit-name copyright">© 2025 code VAMPIRE. All rights reserved.</div>
       <div class="credit-role">Special Thanks</div>

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,7 @@ import {
 } from './vampire.js'
 import { setupCross, updateCross, getCrossRects } from './cross.js'
 import { setupProjectiles, updateProjectiles } from './projectile.js'
-import { setupWerewolves, updateWerewolves, getWerewolfElements } from './werewolf.js'
+import { setupWerewolves, updateWerewolves, getWerewolfElements, stopWolfGrowls } from './werewolf.js'
 import { setupDivineKnight, walkOntoScreen, removeDivineKnight, startKnightAI, getKnightElement, getKnightRect, getKnightAttackRect, startDying, setKnightDyingFrame, getKnightX } from './divineKnight.js'
 import { setupMana, updateMana } from './mana.js'
 import { showBossHealth, hideBossHealth } from './boss.js'
@@ -300,6 +300,7 @@ function stepOffscreen(time) {
 }
 
 function transitionToBossArea() {
+  stopWolfGrowls()
   transitionOverlay.classList.add('fade-out')
   setTimeout(() => {
     document.querySelectorAll('[data-background]').forEach(bg => bg.style.display = 'none')
@@ -610,7 +611,7 @@ function restartFromCredits(e) {
     fireSound.volume = 0.4
     fireSound.play()
 
-  if (navigator.vibrate) navigator.vibrate(100)
+  // Vibration removed to prevent potential freezing on some devices
   const vampireElem = document.querySelector('[data-vampire]')
   vampireElem.classList.add('damaged')
   screenFlash.classList.add('active')

--- a/js/werewolf.js
+++ b/js/werewolf.js
@@ -19,6 +19,12 @@ const DEAD_FRAME_TIME = 200
 const wolfGrowlSound = document.getElementById('wolf-growls')
 if (wolfGrowlSound) wolfGrowlSound.volume = 0.4
 
+export function stopWolfGrowls() {
+  if (!wolfGrowlSound) return
+  wolfGrowlSound.pause()
+  wolfGrowlSound.currentTime = 0
+}
+
 let nextSpawnTime = SPAWN_INTERVAL_MIN
 
 export function setupWerewolves() {


### PR DESCRIPTION
## Summary
- tighten spacing around music credits
- stop wolf growl audio when transitioning to the boss
- remove device vibration that caused brief freezes when hit

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684e45847f648322904147a018030cc3